### PR TITLE
Updated markdown-content.mdx in guides

### DIFF
--- a/src/content/docs/de/guides/markdown-content.mdx
+++ b/src/content/docs/de/guides/markdown-content.mdx
@@ -244,7 +244,7 @@ const posts = await Astro.glob<Frontmatter>('../pages/post/*.md');
 ---
 
 <ul>
-  {posts.map(post => <li>{post.title}</li>)}
+  {posts.map(post => <li>{post.frontmatter.title}</li>)}
   <!-- post.title ist vom Typ `string`! -->
 </ul>
 ```


### PR DESCRIPTION
inserted frontmatter to:
old:
<ul>
  {posts.map(post => <li>{post.title}</li>)}
  <!-- post.title ist vom Typ `string`! -->
</ul>
new:
<ul>
  {posts.map(post => <li>{post.frontmatter.title}</li>)}
  <!-- post.title ist vom Typ `string`! -->
</ul>

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

<!-- Please make changes in **one language** only -->

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->

<!-- For a new/changed feature in an upcoming Astro release? -->
<!-- 1. Uncomment the line below, update the minor version number if known, and include a PR link -->
<!-- #### For Astro version: `4.x`. See astro PR [#](url). -->

<!-- 2. Check that your PR includes `<p><Since v="4.x.0" /></p>` and imports the `<Since>` component, if necessary! -->

<!-- #### First-time contributor to Astro Docs? -->

<!-- If you are a member of the Astro Discord, please add your username in the description so we can welcome you there! -->
<!-- https://astro.build/chat -->

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->
